### PR TITLE
Create CounterweightKateV1.2.cjm

### DIFF
--- a/C/CounterweightKateV1.2.cjm
+++ b/C/CounterweightKateV1.2.cjm
@@ -1,0 +1,3 @@
+X:pal,driveicon,readonly
+J:2*:JU,JD,JL,JR,JF,JF,JF,JF,JF,JF,JF,JF,JF
+V:8


### PR DESCRIPTION
Explicitly specify PAL since Counterweight Kate needs this to work on NTSC c64mini machines.
Virtual screen position adjustment to avoid decaptitating Kate in the status information.
